### PR TITLE
fix autoconfigure function not working in local environments

### DIFF
--- a/geonode/contrib/monitoring/models.py
+++ b/geonode/contrib/monitoring/models.py
@@ -1599,7 +1599,11 @@ def do_autoconfigure():
     # get list of services
     wsite = urlparse(settings.SITEURL)
     # default host
-    hosts = [(wsite.hostname, gethostbyname(wsite.hostname),)]
+    try:
+        _host_by_name = gethostbyname(wsite.hostname)
+    except BaseException:
+        _host_by_name = '127.0.0.1'
+    hosts = [(wsite.hostname, _host_by_name,)]
     # default geonode
     geonode_name = settings.MONITORING_SERVICE_NAME or '{}-geonode'.format(
         wsite.hostname)


### PR DESCRIPTION
Armar un Pull Request bien detallado ayuda a que sea facil de entender para todos.

## Tarea de Origen

Link: https://github.com/scanterra/geonode_generic/issues/6

## Descripcion

Problema dentro de la aplicación Geonode al momento de instanciarla en un entorno dockerizado local.

## Bug fixes

Arregla la instalación de la versión (actual 2.9) de Geonode para ser utilizada dentro de geonode_generic.

