### PR TITLE
Geonode muestra un error al cargar una capa, aun cuando se carga de manera satisfactoria

### DIFF
--- a/geonode/static/geonode/js/upload/LayerInfo.js
+++ b/geonode/static/geonode/js/upload/LayerInfo.js
@@ -586,7 +586,17 @@ define(function (require, exports) {
                 if (jqXHR === null) {
                     self.markError(gettext('Unexpected Error'));
                 } else {
-                    self.markError(jqXHR);
+                    const TIMEOUT_TEXT = '504 Gateway Time-out';
+                    if (typeof jqXHR === 'string' && jqXHR.includes(TIMEOUT_TEXT)) {
+                        console.log('DEBUG: Geonode shows an error when a layer is uploaded successfully');
+                        self.logStatus({
+                            msg: '<p>' + gettext('Layer files uploaded, configuring in GeoServer') + '</p>',
+                            level: 'alert-success',
+                            empty: 'true'
+                        });
+                    } else {
+                        self.markError(jqXHR);
+                    }
                 }
             },
             success: function (resp, status) {


### PR DESCRIPTION

## Tarea de Origen

Link: 

## Descripcion

Cargar una capa muestra el error `Gateway Time-out` aún cuando se carga de manera satisfactoria.
Solución planteada: ocultar el mensaje de error al cargar una capa.

## Bug fixes

Ocultar el error en el caso que la respuesta del backend de Geonode upload layer sea `Gateway Time-out`.
